### PR TITLE
fix: If the absolute path is too long, QFile failed to create file. u…

### DIFF
--- a/include/vcard/vcard.h
+++ b/include/vcard/vcard.h
@@ -51,7 +51,7 @@ public:
     QByteArray toByteArray(vCardVersion version = VC_VER_2_1) const;
 
     bool saveToFile(const QString& filename) const;
-    bool static saveToFile(const QList<vCard> &vCardList, const QString &filename);
+    bool static saveToFile(const QList<vCard> &vCardList, const QString &filepath);
 
     static QList<vCard> fromByteArray(const QByteArray& data);
     static QList<vCard> fromFile(const QString& filename);

--- a/libvcard/vcard.cpp
+++ b/libvcard/vcard.cpp
@@ -21,7 +21,9 @@
  */
 
 #include "vcard.h"
+#include <QtCore/QDir>
 #include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 
 vCard::vCard()
 {
@@ -209,16 +211,27 @@ bool vCard::saveToFile(const QString& filename) const
     return false;
 }
 
-bool vCard::saveToFile(const QList<vCard> &vCardList, const QString &filename)
+bool vCard::saveToFile(const QList<vCard> &vCardList, const QString &filepath)
 {
-    QFile output(filename);
-    if (output.open(QFile::WriteOnly)) {
-        foreach (auto v, vCardList) {
-            output.write(v.toByteArray() + VC_END_LINE_TOKEN);
-        }
-        output.close();
+    QFileInfo fi(filepath);
+    QString sPath = fi.path();
+    QString sName = fi.fileName();
 
-        return true;
+    QDir dir = QDir::root();
+    if (dir.cd(sPath)) {
+
+        QFile file(dir.filePath(sName));
+
+        if (file.open(QFile::WriteOnly)) {
+
+            foreach (auto v, vCardList) {
+                file.write(v.toByteArray() + VC_END_LINE_TOKEN);
+            }
+
+            file.close();
+
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
…se the standard method of Qt.